### PR TITLE
use the right TTLs

### DIFF
--- a/draft-hardaker-dnsop-intentionally-temporarily-insecure.md
+++ b/draft-hardaker-dnsop-intentionally-temporarily-insecure.md
@@ -109,13 +109,13 @@ Below are the enumerated steps required by this alternate transition
 mechanism.  Note that there are still two critical waiting time
 requirements (steps 2 and 6) that must be followed carefully.
 
-1. Optional: lower the TTLs of the zone's DS record (if possible) and
-   the SOA's negative TTL (MINIMUM) {{RFC1035}}.
+1. Optional: lower the TTLs of the zone's DS record (if possible),
+   and the TTL of the DNSKEY RRset.
 
 2. Remove all DS records from the parent zone.
 
 3. Ensure the zone is considered unsigned by all validating resolvers
-   by waiting 2 times the maximum TTL length for the DS record to
+   by waiting 2 times the maximum TTL length for the DS record, and/or 2 times the DNSKEY TTL (whichever is larger) to
    expire from caches.  This is the most critical timing.  The author
    of this document failed to wait the required time once.  It was not
    pretty.
@@ -123,7 +123,7 @@ requirements (steps 2 and 6) that must be followed carefully.
 4. Replace the old DNSKEY(s) with the old algorithm with new DNSKEY(s)
    with the new algorithm(s) in the zone and publish the zone.
    
-6. Wait 2 times the zone SOA's published negative cache time to ensure
+6. Wait 2 times the TTL of the DNSKEY RRset to ensure
    the new DNSKEYs will be found by validating resolvers.
 
 7. Add the DS record(s) for the new DNSKEYs to the parent zone.

--- a/draft-hardaker-dnsop-intentionally-temporarily-insecure.md
+++ b/draft-hardaker-dnsop-intentionally-temporarily-insecure.md
@@ -115,7 +115,7 @@ requirements (steps 2 and 6) that must be followed carefully.
 2. Remove all DS records from the parent zone.
 
 3. Ensure the zone is considered unsigned by all validating resolvers
-   by waiting 2 times the maximum TTL length for the DS record, and/or 2 times the DNSKEY TTL (whichever is larger) to
+   by waiting 2 times the maximum TTL length for the DS record, and/or 2 times the largest TTL found in the zone (whichever is larger) to
    expire from caches.  This is the most critical timing.  The author
    of this document failed to wait the required time once.  It was not
    pretty.
@@ -123,7 +123,7 @@ requirements (steps 2 and 6) that must be followed carefully.
 4. Replace the old DNSKEY(s) with the old algorithm with new DNSKEY(s)
    with the new algorithm(s) in the zone and publish the zone.
    
-6. Wait 2 times the TTL of the DNSKEY RRset to ensure
+6. Wait 2 times the largest TTL found in the zone to ensure
    the new DNSKEYs will be found by validating resolvers.
 
 7. Add the DS record(s) for the new DNSKEYs to the parent zone.


### PR DESCRIPTION
I believe the SOA MINIMUM/SOA TTL/SOA negative of the child zone have little to do with this process.

.. as I write this, I realise NSEC/NSEC3 do use SOA numbers, and as I realise that, I also suspect that in fact the right time to wait should be based on the highest TTL found anywhere in the zone, not just the DNSKEY RRset. WIll push a second commit to address that so you have two versions to look at.